### PR TITLE
Move "force change" checkbox in backend form

### DIFF
--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -28,5 +28,5 @@ $newBeUsersColumns = array(
 );
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('be_users', $newBeUsersColumns);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('be_users', 'tx_cdsrcbepwreset_resetAtNextLogin');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('be_users', 'tx_cdsrcbepwreset_resetAtNextLogin', '', 'after:password');
 


### PR DESCRIPTION
Thanks for your great extension, I really like it and often use it. In my opinion, it would be great to have the  "Force password change at next login" checkbox just after the password field in backend form for easier access.

This tiny pull requests moves the fiels just there.

![force](https://user-images.githubusercontent.com/16088567/41282750-257f1b1c-6e35-11e8-8679-bde8bc257fe6.png)
